### PR TITLE
Update python dependencies

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ app.config['CORS_HEADERS'] = 'Content-Type'
 
 # import en_core_web_sm
 # nlp = en_core_web_sm.load()
-nlp=spacy.load('en')
+nlp = spacy.load("en_core_web_sm")
 np_labels=set(['nsubj','dobj','pobj','iobj','conj','nsubjpass','appos','nmod','poss','parataxis','advmod','advcl'])
 subj_labels=set(['nsubj','nsubjpass','csubj','csubjpass'])
 modifiers=['nummod','compound','amod','punct']

--- a/location_2.py
+++ b/location_2.py
@@ -39,7 +39,7 @@ orth_dist=0
 
 # import en_core_web_sm
 # nlp = en_core_web_sm.load()
-nlp=spacy.load('en')
+nlp = spacy.load("en_core_web_sm")
 tknzr=TweetTokenizer(strip_handles=True,reduce_len=True)
 # import CMUTweetTagger
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 Flask==1.0.2
 stop_words==2018.7.23
 wordsegment==1.3.1
-networkx==2.2
+networkx==2.5.1
 nltk==3.4
 jellyfish==0.7.1
 geocoder==1.38.1
-spacy==2.0.18
+spacy==2.3.5
 emoji==0.5.1
 Flask-Cors==3.0.7
 word2number==1.1
 gunicorn==19.9.0
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz#egg=en_core_web_sm
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz


### PR DESCRIPTION
It has been a while since the python modules used have been updated. As a result of updates to the spacy library as well as Python itself (currently at 3.9.1), it is not possible to run the python server out of the box.

This PR updates spacy & networkx to the latest minimum versions to make the system work.
Tested via the postman collection & UI both.